### PR TITLE
Fix for bad middleware checks when wrapping them on load

### DIFF
--- a/django/contrib/sessions/middleware.py
+++ b/django/contrib/sessions/middleware.py
@@ -11,7 +11,7 @@ from django.utils.http import http_date
 
 class SessionMiddleware(MiddlewareMixin):
     def __init__(self, get_response=None):
-        self.get_response = get_response
+        super().__init__(get_response)
         engine = import_module(settings.SESSION_ENGINE)
         self.SessionStore = engine.SessionStore
 

--- a/django/utils/deprecation.py
+++ b/django/utils/deprecation.py
@@ -87,12 +87,12 @@ class MiddlewareMixin:
     def __init__(self, get_response=None):
         print(f'FIXME: MiddlewareMixin.__init__({type(self).__name__}): get_response={get_response!r}')
         self.get_response = get_response
-        if hasattr(self, 'process_request'):  # FIXME: iscoroutinefunction...
+        if hasattr(self, 'process_request') and not iscoroutinefunction(self.process_request):
             self.process_request = sync_to_async(self.process_request)
         if hasattr(self, 'get_response') and not iscoroutinefunction(self.get_response):
             print('FIXME: wrapping get_response')
             self.get_response = sync_to_async(self.get_response)
-        if hasattr(self, 'process_response'):  # FIXME: iscoroutinefunction...
+        if hasattr(self, 'process_response') and not iscoroutinefunction(self.process_response):
             self.process_response = sync_to_async(self.process_response)
         super().__init__()
 
@@ -101,7 +101,6 @@ class MiddlewareMixin:
         if hasattr(self, 'process_request'):
             response = await self.process_request(request)
         print(f'FIXME: MiddlewareMixin after process_request: response={response!r}')
-        import pdb; pdb.set_trace()  # FIXME
         response = response or await self.get_response(request)
         print(f'FIXME: MiddlewareMixin after get_response: response={response!r}')
         if hasattr(self, 'process_response'):


### PR DESCRIPTION
This fixes the issues we were having yesterday. Let me know what you think. 

Ideally, I'd like to completely get rid of `_is_async`. We can discuss a bit more about how this can be done today. We may need to explore the different ways of writing middleware and check the appropriate method/functions in them